### PR TITLE
Disabling use of idfile to RedHat/CentOS 5 with monit 4.x

### DIFF
--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -2,7 +2,9 @@
 #
 set daemon <%= @check_interval %>
 set logfile <%= @logfile %>
+<%- unless @operatingsystemmajrelease == "5" and @osfamily == "RedHat" -%>
 set idfile /var/lib/monit/id
+<%- end -%>
 set statefile /var/lib/monit/state
 <%- if @mailserver -%>
 set mailserver <%= @mailserver %>


### PR DESCRIPTION
monit 4.x on RedHat/CentOS 5 doesn't support the "idfile"-entry in monit.conf. This disables this line if osfamily == "RedHat" and operatingsystemmajrelase == "5"
