### PR TITLE
Add More Mail Config Options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,9 @@
 #   Custom mail-format options hash.
 #   Default: undef
 #
+# [*alert_emails*]
+#   Array of email address to send global alerts to.
+#   Default: []
 # === Examples
 #
 #  class { 'monit':
@@ -111,6 +114,7 @@ class monit (
   $logfile         = $monit::params::logfile,
   $mailserver      = $monit::params::mailserver,
   $mailformat      = $monit::params::mailformat,
+  $alert_emails    = $monit::params::alert_emails,
 ) inherits monit::params {
   if ! is_integer($check_interval) {
     fail('Invalid type. check_interval param should be an integer.')
@@ -138,6 +142,7 @@ class monit (
   if $mailformat {
     validate_hash($mailformat)
   }
+  validate_array($alert_emails)
 
   anchor { "${module_name}::begin": } ->
   class { "${module_name}::install": } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,6 +70,10 @@
 #   If set to a string, alerts will be sent by email to this mailserver.
 #   Default: undef
 #
+# [*mailformat*]
+#   Custom mail-format options hash.
+#   Default: undef
+#
 # === Examples
 #
 #  class { 'monit':
@@ -106,6 +110,7 @@ class monit (
   $config_dir      = $monit::params::config_dir,
   $logfile         = $monit::params::logfile,
   $mailserver      = $monit::params::mailserver,
+  $mailformat      = $monit::params::mailformat,
 ) inherits monit::params {
   if ! is_integer($check_interval) {
     fail('Invalid type. check_interval param should be an integer.')
@@ -129,6 +134,9 @@ class monit (
   validate_string($logfile)
   if $mailserver {
     validate_string($mailserver)
+  }
+  if $mailformat {
+    validate_hash($mailformat)
   }
 
   anchor { "${module_name}::begin": } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class monit::params {
   $service_name    = 'monit'
   $logfile         = '/var/log/monit.log'
   $mailserver      = undef
+  $mailformat      = undef
 
   case $::osfamily {
     'Debian': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class monit::params {
   $logfile         = '/var/log/monit.log'
   $mailserver      = undef
   $mailformat      = undef
+  $alert_emails    = []
 
   case $::osfamily {
     'Debian': {

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -14,6 +14,9 @@ set mail-format {
 <%- end -%>
 }
 <%- end -%>
+<%- @alert_emails.each do |email| -%>
+set alert <%= email %>
+<%- end -%>
 set eventqueue
     basedir /var/lib/monit/events
     slots 100

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -7,6 +7,13 @@ set statefile /var/lib/monit/state
 <%- if @mailserver -%>
 set mailserver <%= @mailserver %>
 <%- end -%>
+<%- if @mailformat -%>
+set mail-format {
+<%- @mailformat.each do |key, value| -%>
+    <%= key %>: <%= value %>
+<%- end -%>
+}
+<%- end -%>
 set eventqueue
     basedir /var/lib/monit/events
     slots 100


### PR DESCRIPTION
This PR proposes support for the `mailformat` and `alert` options within monitrc. Happy to make any changes necessary.