### PR TITLE
Added configuration option to set an M/Monit report server in Monit config file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,9 @@
 # [*mmonit_address*]
 #   Remote address of an M/Monit server to be used by Monit agent for report.
 #   If set to undef, M/Monit connection is disabled.
+#   WARNING: If this option is set, and Monit agent version is less than 5, then
+#            module will fail (this option is available in Monit Agent version 5
+#            and above.
 #   Default: undef
 #
 # [*mmonit_port*]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,29 @@
 #   Array of email address to send global alerts to.
 #   Default: []
 #
+# [*mmonit_address*]
+#   Remote address of an M/Monit server to be used by Monit agent for report.
+#   If set to undef, M/Monit connection is disabled.
+#   Default: undef
+#
+# [*mmonit_port*]
+#   Remote port of the M/Monit server
+#   Default: '8080'
+#
+# [*mmonit_user*]
+#   User to connect to the remote M/Monit server
+#   Default: 'monit'
+#
+# [*mmonit_password*]
+#   Password of the account used to connect to the remote M/Monit server
+#   Default: 'monit'
+#
+# [*mmonit_without_credential*]
+#   By default Monit registers credentials with M/Monit so M/Monit can smoothly
+#   communicate back to Monit and you don't have to register Monit credentials manually in M/Monit.
+#   It is possible to disable credential registration setting this option to 'true'.
+#   Default: false
+#
 # === Examples
 #
 #  class { 'monit':
@@ -97,25 +120,30 @@
 # Copyright 2014-2015 Echoes Technologies SAS, unless otherwise noted.
 #
 class monit (
-  $check_interval  = $monit::params::check_interval,
-  $httpd           = $monit::params::httpd,
-  $httpd_port      = $monit::params::httpd_port,
-  $httpd_address   = $monit::params::httpd_address,
-  $httpd_user      = $monit::params::httpd_user,
-  $httpd_password  = $monit::params::httpd_password,
-  $manage_firewall = $monit::params::manage_firewall,
-  $package_ensure  = $monit::params::package_ensure,
-  $package_name    = $monit::params::package_name,
-  $service_enable  = $monit::params::service_enable,
-  $service_ensure  = $monit::params::service_ensure,
-  $service_manage  = $monit::params::service_manage,
-  $service_name    = $monit::params::service_name,
-  $config_file     = $monit::params::config_file,
-  $config_dir      = $monit::params::config_dir,
-  $logfile         = $monit::params::logfile,
-  $mailserver      = $monit::params::mailserver,
-  $mailformat      = $monit::params::mailformat,
-  $alert_emails    = $monit::params::alert_emails,
+  $check_interval            = $monit::params::check_interval,
+  $httpd                     = $monit::params::httpd,
+  $httpd_port                = $monit::params::httpd_port,
+  $httpd_address             = $monit::params::httpd_address,
+  $httpd_user                = $monit::params::httpd_user,
+  $httpd_password            = $monit::params::httpd_password,
+  $manage_firewall           = $monit::params::manage_firewall,
+  $package_ensure            = $monit::params::package_ensure,
+  $package_name              = $monit::params::package_name,
+  $service_enable            = $monit::params::service_enable,
+  $service_ensure            = $monit::params::service_ensure,
+  $service_manage            = $monit::params::service_manage,
+  $service_name              = $monit::params::service_name,
+  $config_file               = $monit::params::config_file,
+  $config_dir                = $monit::params::config_dir,
+  $logfile                   = $monit::params::logfile,
+  $mailserver                = $monit::params::mailserver,
+  $mailformat                = $monit::params::mailformat,
+  $alert_emails              = $monit::params::alert_emails,
+  $mmonit_address            = $monit::params::mmonit_address,
+  $mmonit_port               = $monit::params::mmonit_port,
+  $mmonit_user               = $monit::params::mmonit_user,
+  $mmonit_password           = $monit::params::mmonit_password,
+  $mmonit_without_credential = $monit::params::mmonit_without_credential,
 ) inherits monit::params {
   if ! is_integer($check_interval) {
     fail('Invalid type. check_interval param should be an integer.')
@@ -144,6 +172,13 @@ class monit (
     validate_hash($mailformat)
   }
   validate_array($alert_emails)
+  if $mmonit_server_address {
+    validate_string($mmonit_address)
+    validate_string($mmonit_port)
+    validate_string($mmonit_user)
+    validate_string($mmonit_password)
+    validate_bool($mmonit_without_credential)
+  }
 
   anchor { "${module_name}::begin": } ->
   class { "${module_name}::install": } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,6 +144,7 @@ class monit (
   $mmonit_user               = $monit::params::mmonit_user,
   $mmonit_password           = $monit::params::mmonit_password,
   $mmonit_without_credential = $monit::params::mmonit_without_credential,
+  $monit_version             = $monit::params::monit_version,
 ) inherits monit::params {
   if ! is_integer($check_interval) {
     fail('Invalid type. check_interval param should be an integer.')
@@ -172,7 +173,12 @@ class monit (
     validate_hash($mailformat)
   }
   validate_array($alert_emails)
-  if $mmonit_server_address {
+  
+  if $mmonit_address {
+    if $monit_version == 4 {
+      # if $mmonit_address != undef => fails (option is not compatible with monit < 5
+      fail('M/Monit option (via mmonit_* parameters needs Monit agent >= 5')
+    }
     validate_string($mmonit_address)
     validate_string($mmonit_port)
     validate_string($mmonit_user)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,7 +178,7 @@ class monit (
   validate_array($alert_emails)
   
   if $mmonit_address {
-    if $monit_version == 4 {
+    if $monit_version == '4' {
       # if $mmonit_address != undef => fails (option is not compatible with monit < 5
       fail('M/Monit option (via mmonit_* parameters needs Monit agent >= 5')
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,23 +2,28 @@
 #
 # This is a container class with default parameters for monit classes.
 class monit::params {
-  $check_interval  = 120
-  $httpd           = false
-  $httpd_port      = 2812
-  $httpd_address   = 'localhost'
-  $httpd_user      = 'admin'
-  $httpd_password  = 'monit'
-  $manage_firewall = false
-  $package_ensure  = 'present'
-  $package_name    = 'monit'
-  $service_enable  = true
-  $service_ensure  = 'running'
-  $service_manage  = true
-  $service_name    = 'monit'
-  $logfile         = '/var/log/monit.log'
-  $mailserver      = undef
-  $mailformat      = undef
-  $alert_emails    = []
+  $check_interval            = 120
+  $httpd                     = false
+  $httpd_port                = 2812
+  $httpd_address             = 'localhost'
+  $httpd_user                = 'admin'
+  $httpd_password            = 'monit'
+  $manage_firewall           = false
+  $package_ensure            = 'present'
+  $package_name              = 'monit'
+  $service_enable            = true
+  $service_ensure            = 'running'
+  $service_manage            = true
+  $service_name              = 'monit'
+  $logfile                   = '/var/log/monit.log'
+  $mailserver                = undef
+  $mailformat                = undef
+  $alert_emails              = []
+  $mmonit_address            = undef
+  $mmonit_port               = '8080'
+  $mmonit_user               = 'monit'
+  $mmonit_password           = 'monit'
+  $mmonit_without_credential = false
 
   case $::osfamily {
     'Debian': {
@@ -43,8 +48,15 @@ class monit::params {
         $monit_version = 5
       }
       $service_hasstatus = true
-      $config_file       = '/etc/monit.conf'
       $config_dir        = '/etc/monit.d'
+
+      if versioncmp($::operatingsystemrelease, 7) < 0 {
+	$config_file       = '/etc/monit.conf'
+      } else {
+        $config_file       = '/etc/monitrc'
+      }
+
+
     }
     default: {
       fail("Unsupported OS family: ${::osfamily}")

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -29,4 +29,10 @@ set httpd port <%= @httpd_port %> and
    allow <%= @httpd_user %>:<%= @httpd_password %>
 <%- end -%>
 
+<%- if @mmonit_address  -%>
+set mmonit http://<%= @mmonit_user %>:<%= @mmonit_password %>@<%= @mmonit_address %>:<%= @mmonit_port %>/collector
+   <%- if @mmonit_without_credential -%>and register without credentials<%- end -%>
+<%- end -%>
+
+
 include <%= @config_dir %>/*


### PR DESCRIPTION
Added in the sametime support for CentOS 7 (config file is /etc/monitrc, not /etc/monit.conf)