### PR TITLE
Make authentication optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,10 +22,12 @@
 #
 # [*httpd_user*]
 #   User to access the Monit Dashboard
+#   If you set both user and password to an empty string, authentication is disabled.
 #   Default: 'admin'
 #
 # [*httpd_password*]
 #   Password to access the Monit Dashboard
+#   If you set both user and password to an empty string, authentication is disabled.
 #   Default: 'monit'
 #
 # [*manage_firewall*]

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -29,7 +29,9 @@ set eventqueue
 set httpd port <%= @httpd_port %> and
    use address <%= @httpd_address %>
    allow 0.0.0.0/0.0.0.0
+   <%- if !@httpd_user.empty? && !@httpd_password.empty? -%>
    allow <%= @httpd_user %>:<%= @httpd_password %>
+   <%- end -%>
 <%- end -%>
 <%- if @mmonit_address  -%>
 set mmonit http://<%= @mmonit_user %>:<%= @mmonit_password %>@<%= @mmonit_address %>:<%= @mmonit_port %>/collector


### PR DESCRIPTION
This adds support to run Monit without authentication.

Authentication is only disabled if the user explicitely sets username and password to empty strings. If he does not set username and passwords, the defaults (admin/monit) are used. So the current functionality is not changed and the user can not accidentally disable authentication.