### PR TITLE
Correct scoping of monit_version in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@ class monit (
   }
   validate_array($alert_emails)
   validate_integer($start_delay, undef, 0)
-  if($start_delay > 0 and $::monit_version < '5') {
+  if($start_delay > 0 and $::monit::params::monit_version < '5') {
     fail('Monit option "start_delay" requires at least Monit 5.0"')
   }
   if $mmonit_address {


### PR DESCRIPTION
I'm using start_delay and encountering comparison errors when puppet tries to compare $::monit_version, which evaluates as nil.  Scoping as $::monit::params::monit_version addresses this.

Thanks for sharing this module, it's looking quite useful for us!