### PR TITLE
Added global alert_context option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ The following parameters are available in the `::monit` class:
 
 Specifies one or more email addresses to send global alerts to. Valid options: array. Default value: []
 
-##### `alert_overrides`
+##### `alert_context`
 
-Specifies global alert overrides in the form `only on { timeout, nonexist }` or `but not on { instance }`. See: https://mmonit.com/monit/documentation/monit.html#Setting-an-event-filter Default value: ''
+Specifies global alert context in the form `only on { timeout, nonexist }` or `but not on { instance }`. See: https://mmonit.com/monit/documentation/monit.html#Setting-an-event-filter Default value: ''
 
 ##### `check_interval`
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ The following parameters are available in the `::monit` class:
 
 Specifies one or more email addresses to send global alerts to. Valid options: array. Default value: []
 
+##### `alert_overrides`
+
+Specifies global alert overrides in the form `only on { timeout, nonexist }` or `but not on { instance }`. See: https://mmonit.com/monit/documentation/monit.html#Setting-an-event-filter Default value: ''
+
 ##### `check_interval`
 
 Specifies the interval between two checks of Monit. Valid options: numeric. Default value: 120

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class monit (
   $mailserver                = $monit::params::mailserver,
   $mailformat                = $monit::params::mailformat,
   $alert_emails              = $monit::params::alert_emails,
-  $alert_overrides           = $monit::params::alert_overrides,
+  $alert_context             = $monit::params::alert_context,
   $start_delay               = $monit::params::start_delay,
   $mmonit_address            = $monit::params::mmonit_address,
   $mmonit_port               = $monit::params::mmonit_port,
@@ -53,7 +53,7 @@ class monit (
     validate_hash($mailformat)
   }
   validate_array($alert_emails)
-  validate_string($alert_overrides)
+  validate_string($alert_context)
   validate_integer($start_delay, undef, 0)
   if($start_delay > 0 and $::monit_version < '5') {
     fail('Monit option "start_delay" requires at least Monit 5.0"')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class monit (
   $mailserver                = $monit::params::mailserver,
   $mailformat                = $monit::params::mailformat,
   $alert_emails              = $monit::params::alert_emails,
+  $alert_overrides           = $monit::params::alert_overrides,
   $start_delay               = $monit::params::start_delay,
   $mmonit_address            = $monit::params::mmonit_address,
   $mmonit_port               = $monit::params::mmonit_port,
@@ -52,6 +53,7 @@ class monit (
     validate_hash($mailformat)
   }
   validate_array($alert_emails)
+  validate_string($alert_overrides)
   validate_integer($start_delay, undef, 0)
   if($start_delay > 0 and $::monit_version < '5') {
     fail('Monit option "start_delay" requires at least Monit 5.0"')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class monit::params {
   $mailserver                = undef
   $mailformat                = undef
   $alert_emails              = []
-  $alert_overrides           = ''
+  $alert_context             = ''
   $start_delay               = 0
   $mmonit_address            = undef
   $mmonit_port               = '8080'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class monit::params {
   $mailserver                = undef
   $mailformat                = undef
   $alert_emails              = []
+  $alert_overrides           = ''
   $start_delay               = 0
   $mmonit_address            = undef
   $mmonit_port               = '8080'

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -20,7 +20,7 @@ set mail-format {
 }
 <%- end -%>
 <%- @alert_emails.each do |email| -%>
-set alert <%= email %>
+set alert <%= email %> <%= @alert_overrides %>
 <%- end -%>
 set eventqueue
     basedir /var/lib/monit/events

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -20,7 +20,7 @@ set mail-format {
 }
 <%- end -%>
 <%- @alert_emails.each do |email| -%>
-set alert <%= email %> <%= @alert_overrides %>
+set alert <%= email %> <%= @alert_context %>
 <%- end -%>
 set eventqueue
     basedir /var/lib/monit/events


### PR DESCRIPTION
Allows:

```
  class { 'monit':
    alert_emails  => 'example@email.com',
    alert_context => 'but not on { pid, resource, instance }',
  }
```

which results in the following in `monitrc`:

```
 set alert example@email.com but not on { pid, resource, instance }
```

Ref: https://mmonit.com/monit/documentation/monit.html#Setting-an-event-filter
