### PR TITLE
handle puppet strict_variables

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,7 +111,7 @@ class monit (
 
   # Use the monit_version fact if available, else use the default for the
   # platform.
-  if $::monit_version {
+  if defined('$::monit_version') and $::monit_version {
     $monit_version_real = $::monit_version
   } else {
     $monit_version_real = $monit::params::monit_version


### PR DESCRIPTION
The precedent version fails with `strict_variables` enabled on the puppetserver side.
