### PR TITLE
Add httpd_allow and include directive configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class monit (
   $httpd_address             = $monit::params::httpd_address,
   $httpd_user                = $monit::params::httpd_user,
   $httpd_password            = $monit::params::httpd_password,
+  $httpd_allow               = $monit::params::httpd_allow,
   $manage_firewall           = $monit::params::manage_firewall,
   $package_ensure            = $monit::params::package_ensure,
   $package_name              = $monit::params::package_name,
@@ -17,6 +18,7 @@ class monit (
   $config_file               = $monit::params::config_file,
   $config_dir                = $monit::params::config_dir,
   $config_dir_purge          = $monit::params::config_dir_purge,
+  $config_include            = $monit::params::config_include,
   $logfile                   = $monit::params::logfile,
   $mailserver                = $monit::params::mailserver,
   $mailformat                = $monit::params::mailformat,
@@ -73,6 +75,7 @@ class monit (
   validate_string($httpd_address)
   validate_string($httpd_user)
   validate_string($httpd_password)
+  validate_string($httpd_allow)
   validate_bool($manage_firewall_bool)
   validate_string($package_ensure)
   validate_string($package_name)
@@ -106,6 +109,7 @@ class monit (
   validate_bool($mmonit_without_credential_bool)
   validate_absolute_path($config_file)
   validate_absolute_path($config_dir)
+  validate_array($config_include)
   validate_bool($config_dir_purge_bool)
   # </variable validations>
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,11 +4,13 @@
 class monit::params {
   $check_interval            = 120
   $config_dir_purge          = false
+  $config_include            = []
   $httpd                     = false
   $httpd_port                = 2812
   $httpd_address             = 'localhost'
   $httpd_user                = 'admin'
   $httpd_password            = 'monit'
+  $httpd_allow               = '0.0.0.0/0.0.0.0'
   $manage_firewall           = false
   $package_ensure            = 'present'
   $package_name              = 'monit'

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -37,9 +37,8 @@ set httpd port <%= @httpd_port %> and
 set mmonit http://<%= @mmonit_user %>:<%= @mmonit_password %>@<%= @mmonit_address %>:<%= @mmonit_port %>/collector
 <%- if @mmonit_without_credential_bool -%>   and register without credentials<%- end -%>
 <%- end -%>
-
-include <%= @config_dir -%>/*
-
 <%- @config_include.each do |include| -%>
 include <%= include %>
 <%- end -%>
+
+include <%= @config_dir -%>/*

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -28,7 +28,7 @@ set eventqueue
 <%- if @httpd == true -%>
 set httpd port <%= @httpd_port %> and
    use address <%= @httpd_address %>
-   allow 0.0.0.0/0.0.0.0
+   allow <%= @httpd_allow %>
    <%- if !@httpd_user.empty? && !@httpd_password.empty? -%>
    allow <%= @httpd_user %>:<%= @httpd_password %>
    <%- end -%>
@@ -39,3 +39,7 @@ set mmonit http://<%= @mmonit_user %>:<%= @mmonit_password %>@<%= @mmonit_addres
 <%- end -%>
 
 include <%= @config_dir -%>/*
+
+<%- @config_include.each do |include| -%>
+include <%= include %>
+<%- end -%>


### PR DESCRIPTION
This PR allows for a configurable httpd_allow parameter (default was allow all) and additional include directives.
