### PR TITLE
Make 'message' last element of mail-format in monitrc.erb

### DIFF
--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -12,13 +12,20 @@ set statefile /var/lib/monit/state
 <%- if @mailserver -%>
 set mailserver <%= @mailserver %>
 <%- end -%>
+
 <%- if @mailformat -%>
+<%- @mailformat_message = @mailformat['message'] -%>
+<%- @mailformat.delete('message') -%>
 set mail-format {
 <%- @mailformat.sort.each do |key, value| -%>
     <%= key %>: <%= value %>
 <%- end -%>
+<%- if @mailformat_message -%>
+    message: <%= @mailformat_message %>
+<%- end -%>
 }
 <%- end -%>
+
 <%- @alert_emails.each do |email| -%>
 set alert <%= email %>
 <%- end -%>


### PR DESCRIPTION
Fixes #33.  The "message" element in "mailformat" needs to be the last entry.  Otherwise the elements following "message" after sorting get included in the body of the message.  I've saved the value for "message", removed it from the hash, let the sort happen on the remaining elements, then append the saved message to the mailformat block before closing.

I've tested on my systems both supplying a custom message to the module and supplying no message to the module.

