### PR TITLE
Add SSL and PEM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 2016-11-07 - Release 1.1.2
+## 2018-09-11 - Release 1.1.2
 ### Summary
+Based on release 1.1.2 (2016-11-07) of the original module.
 This release adds support to Ubuntu Xenial and improves compatibility with Puppet Server.
 
 #### Features
+- Adds support for PEM and SSL certificate configuration
 - Added support to Ubuntu 16.04.
 
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ Specifies the user to access the Monit Dashboard. Valid options: string. Default
 
 Specifies the password to access the Monit Dashboard. Valid options: string. Default value: 'monit'
 
+##### `httpd_ssl'
+
+Specifies SSL encryption for access the Monit Dashboard. Valid options: 'true' or 'false'. Default value: 'false'
+
+##### `httpd_pemfile'
+
+Specifies the use of the local PEM module for authentication of access the Monit Dashboard. Valid options: string
+Default value: undef.
+
 ##### `logfile`
 
 Specifies the logfile directive value. Valid options: string. Default value: '/var/log/monit.log'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,8 @@ class monit (
   $httpd_address             = $monit::params::httpd_address,
   $httpd_user                = $monit::params::httpd_user,
   $httpd_password            = $monit::params::httpd_password,
+  $httpd_ssl                 = $monit::params::httpd_ssl,
+  $httpd_pemfile             = $monit::params::httpd_pemfile,
   $manage_firewall           = $monit::params::manage_firewall,
   $package_ensure            = $monit::params::package_ensure,
   $package_name              = $monit::params::package_name,
@@ -64,6 +66,12 @@ class monit (
   } else {
     $config_dir_purge_bool = $config_dir_purge
   }
+
+  if is_string($httpd_ssl) == true {
+    $httpd_ssl_bool = str2bool($httpd_ssl)
+  } else {
+    $httpd_ssl_bool = $httpd_ssl
+  }
   # </stringified variable handling>
 
   # <variable validations>
@@ -73,6 +81,7 @@ class monit (
   validate_string($httpd_address)
   validate_string($httpd_user)
   validate_string($httpd_password)
+  validate_bool($httpd_ssl_bool)
   validate_bool($manage_firewall_bool)
   validate_string($package_ensure)
   validate_string($package_name)
@@ -98,6 +107,10 @@ class monit (
 
   if $mmonit_address != undef {
     validate_string($mmonit_address)
+  }
+
+  if $httpd_pemfile != undef {
+    validate_absolute_path($httpd_pemfile)
   }
 
   validate_string($mmonit_port)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,8 @@ class monit::params {
   $httpd_address             = 'localhost'
   $httpd_user                = 'admin'
   $httpd_password            = 'monit'
+  $httpd_ssl                 = false
+  $httpd_pemfile             = undef
   $manage_firewall           = false
   $package_ensure            = 'present'
   $package_name              = 'monit'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -261,6 +261,29 @@ describe 'monit' do
       it { should contain_file('monit_config').with_content(/#{content}/) }
     end
 
+    context 'when httpd ssl with pem is enabled' do
+      let(:params) do
+        {
+            :httpd          => true,
+            :httpd_ssl      => true,
+            :httpd_pemfile  => 'somePEMfile',
+            :httpd_port     => 2420,
+            :httpd_address  => 'otherhost',
+            :httpd_user     => 'tester',
+            :httpd_password => '',
+        }
+      end
+      content = <<-END.gsub(/^\s+\|/, '')
+        |set httpd port 2420 and
+        |   use address otherhost
+        |   allow 0.0.0.0/0.0.0.0
+        |   ssl enable
+        |   pemfile somePEMfile
+        |   allow tester read-only
+      END
+      it { should contain_file('monit_config').with_content(/#{content}/) }
+    end
+
     context 'when manage_firewall and http are set to valid bool <true>' do
       # kernel fact is needed for ::firewall
       let(:pre_condition) { ['include ::firewall'] }

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -29,6 +29,13 @@ set eventqueue
 set httpd port <%= @httpd_port %> and
    use address <%= @httpd_address %>
    allow 0.0.0.0/0.0.0.0
+   <%- if @httpd_ssl_bool and @httpd_pemfile -%>
+   ssl enable
+   pemfile <%= @httpd_pemfile %>
+      <%- if !@httpd_user.empty? && @httpd_password.empty? -%>
+   allow <%= @httpd_user %> read-only
+      <%- end -%>
+   <%- end -%>
    <%- if !@httpd_user.empty? && !@httpd_password.empty? -%>
    allow <%= @httpd_user %>:<%= @httpd_password %>
    <%- end -%>


### PR DESCRIPTION
This change adds support for SSL and PEM based authentication for monit

Signed-off-by: Wojciech Dec <wdec@cisco.com>